### PR TITLE
Use reflection for collecting properties

### DIFF
--- a/tests/EnumTest.php
+++ b/tests/EnumTest.php
@@ -4,12 +4,12 @@ namespace PaLabs\Tests\Enum;
 
 use Exception;
 use PaLabs\Tests\Enum\Fixtures\ActionEnum;
+use PaLabs\Tests\Enum\Fixtures\ExtendedActionEnum;
 use PaLabs\Tests\Enum\Fixtures\OperationEnum;
 use PHPUnit\Framework\TestCase;
 
 class EnumTest extends TestCase
 {
-
     public function testValuesCount()
     {
         $values = ActionEnum::values();
@@ -46,6 +46,35 @@ class EnumTest extends TestCase
     public function testEnumMethod() {
         $this->assertEquals(3, OperationEnum::$SUM->exec(1, 2));
         $this->assertEquals(-1, OperationEnum::$SUB->exec(1, 2));
+    }
 
+    public function testExtendedEnum()
+    {
+        $actions = ActionEnum::values();
+        $this->assertEquals(ActionEnum::class, get_class($actions[0]));
+        $this->assertEquals(ActionEnum::class, get_class($actions[1]));
+        $this->assertEquals(ActionEnum::class, get_class($actions[2]));
+
+        $this->assertSame(ActionEnum::$VIEW, $actions[0]);
+        $this->assertSame(ActionEnum::$EDIT, $actions[1]);
+        $this->assertSame(ActionEnum::$DELETE, $actions[2]);
+
+
+        $extendedActions = ExtendedActionEnum::values();
+        $this->assertEquals(ActionEnum::class, get_class($extendedActions[0]));
+        $this->assertEquals(ActionEnum::class, get_class($extendedActions[1]));
+        $this->assertEquals(ActionEnum::class, get_class($extendedActions[2]));
+        $this->assertEquals(ExtendedActionEnum::class, get_class($extendedActions[3]));
+
+        $this->assertSame(ActionEnum::$VIEW, $extendedActions[0]);
+        $this->assertSame(ActionEnum::$EDIT, $extendedActions[1]);
+        $this->assertSame(ActionEnum::$DELETE, $extendedActions[2]);
+        $this->assertSame(ExtendedActionEnum::$CLONE, $extendedActions[3]);
+
+        $this->assertEquals(ActionEnum::$DELETE->ordinal(), 2);
+        $this->assertEquals(ExtendedActionEnum::$DELETE->ordinal(), 2);
+        $this->assertEquals(ExtendedActionEnum::$CLONE->ordinal(), 3);
+
+        $this->assertSame(ActionEnum::$VIEW, ExtendedActionEnum::$VIEW);
     }
 }

--- a/tests/Fixtures/ActionEnum.php
+++ b/tests/Fixtures/ActionEnum.php
@@ -6,7 +6,7 @@ namespace PaLabs\Tests\Enum\Fixtures;
 
 use PaLabs\Enum\Enum;
 
-final class ActionEnum extends Enum
+class ActionEnum extends Enum
 {
     public static ActionEnum $VIEW, $EDIT;
     public static ActionEnum $DELETE;

--- a/tests/Fixtures/ExtendedActionEnum.php
+++ b/tests/Fixtures/ExtendedActionEnum.php
@@ -1,0 +1,11 @@
+<?php
+
+
+namespace PaLabs\Tests\Enum\Fixtures;
+
+
+class ExtendedActionEnum extends ActionEnum
+{
+    public static self $CLONE;
+}
+ExtendedActionEnum::init();


### PR DESCRIPTION
Hello. I've been experimenting with very same idea of static enums. Found this lib, you already have bindings for symfony/doctrine, which is nice! So I'd like to contribute.

I see that Enum::properties() does reading and parsing php files, which can be slow when filesystem is slow. I propose using reflection to do this. Reflections are not the fastest method too, but tests showed that it is faster then reading files, since reflected classes are already read.

Here is the benchmark: https://gist.github.com/klkvsk/98eb1c3b1cc35b77ebd86bdc1b8820a3#file-results-txt
Reflection does around 2x better in test with average enums with 10 values. 
In extreme test with 1000 values per enum, reflection and parsing are close in results. But this is on fast SSD. 

Also, I consider reflection more reliable. For example, I'm not sure what would happen in case with parsing, when enum class would be in .phar-file. And also, with reflection + class preloading (opcache), it would work without any disk operations.

Second thing that comes with this, you can collect parent class properties too. That means you can extend Enums. In some cases that's helpful.
I've added some tests to verify extended enums are working.